### PR TITLE
Gather PNG plots into single output HTML dataset

### DIFF
--- a/craft.sh
+++ b/craft.sh
@@ -174,8 +174,11 @@ cat >${OUTPUT_DIR}/plots/plots.html <<EOF
 EOF
 PNGS=$(ls ${OUTPUT_DIR}/plots/*.png)
 for png in $PNGS ; do
+    png=$(basename $png)
+    plot_name=${png%.*}
     cat >>${OUTPUT_DIR}/plots/plots.html <<EOF
-<p><img src="$(basename $png)" alt="$(basename $png)" /></p>
+<h1>$plot_name</h1>
+<p><img src="$png" title="$plot_name" /></p>
 EOF
 done
 cat >>${OUTPUT_DIR}/plots/plots.html <<EOF

--- a/craft.sh
+++ b/craft.sh
@@ -165,3 +165,20 @@ Rscript --vanilla $CRAFT_GP_SCRIPTS/visualisation_main.R \
 	-s $CREDIBLE_SNPS \
 	-e $ANNOTATED_EPIGENOMES \
 	-o ${OUTPUT_DIR}/plots/
+
+# Make a HTML file with all the PNG plots
+cat >${OUTPUT_DIR}/plots/plots.html <<EOF
+<html>
+<head><title>PNG plots</title></head>
+<body>
+EOF
+PNGS=$(ls ${OUTPUT_DIR}/plots/*.png)
+for png in $PNGS ; do
+    cat >>${OUTPUT_DIR}/plots/plots.html <<EOF
+<p><img src="$(basename $png)" alt="$(basename $png)" /></p>
+EOF
+done
+cat >>${OUTPUT_DIR}/plots/plots.html <<EOF
+</body>
+</html>
+EOF

--- a/craft_gp.xml
+++ b/craft_gp.xml
@@ -45,9 +45,12 @@
   ## Collect outputs for annotation
   mv output/annotation/annotation.csv "$output_csv" &&
   mv output/annotation/annotation.vcf "$output_vcf" &&
-  mv output/annotation/annotation.vcf_summary.html "$output_html"
+  mv output/annotation/annotation.vcf_summary.html "$output_html" &&
 
-  ## Outputs for visualisation collected via dataset discovery
+  ## Assemble HTML output with PNG plots
+  mkdir "$output_plots_html.files_path" &&
+  cp output/plots/*.png "$output_plots_html.files_path" &&
+  cp output/plots/plots.html "$output_plots_html"
   ]]></command>
   <inputs>
     <param type="text" name="name" value="test"
@@ -118,15 +121,8 @@
     <data name="output_html" format="html"
 	  label="${tool.name} on ${on_string}: annotated SNPs summary (HTML)" />
     <!-- Visualisation -->
-    <!-- Capture arbitrary number of outputs
-	 See https://wiki.galaxyproject.org/Admin/Tools/Multiple%20Output%20Files#Number_of_Output_datasets_cannot_be_determined_until_tool_run
-	 Not sure if this is correctly implemented below however -->
-    <data format="png" name="plot">
-      <discover_datasets pattern="__designation__"
-			 ext="png"
-			 directory="output/plots"
-			 visible="true" />
-    </data>
+    <data name="output_plots_html" format="html"
+	  label="${tool.name} on ${on_string}: PNG plots (HTML)" />
   </outputs>
   <tests>
   </tests>


### PR DESCRIPTION
PR aiming to address issue #6, by creating a single output HTML dataset and referencing all the PNG plots from there.